### PR TITLE
Add ip address to dns response in pandas

### DIFF
--- a/src/netml/pparser/parser.py
+++ b/src/netml/pparser/parser.py
@@ -1022,6 +1022,7 @@ class PCAP:
                             dnsrr.rrname.decode('utf-8')
                             if isinstance(dnsrr.rrname, bytes)
                             else dnsrr.rrname,
+                            dnsrr.rdata
                         )
                     )
 


### PR DESCRIPTION
The IP address received in a DNS response is missing from the `dataframe` generated by `pcap2pandas`.