### PR TITLE
dns_traffic attribute

### DIFF
--- a/src/netml/pparser/parser.py
+++ b/src/netml/pparser/parser.py
@@ -965,6 +965,7 @@ class PCAP:
               "port_src"  : source port
               "port_dst"  : destination port
               "is_dns"    : True if packet is DNS packet, else False
+              "dns_transaction_id" : floating point DNS transaction ID
               "dns_query" : string DNS query
               "dns_resp"  : string DNS response
 
@@ -987,8 +988,8 @@ class PCAP:
                     'port_src': None,
                     'is_dns': False,
                     'dns_query': None,
-                    'dns_transaction_id': None,
                     'dns_resp': None,
+                    'dns_transaction_id': None,
                 }
 
                 if IP in pkt:
@@ -1009,7 +1010,7 @@ class PCAP:
                 if DNS in pkt:
                     # the transaction ID is stored in the `.id`
                     # attribute of packet's DNS layer
-                    pkt_dict['dns_transaction_id'] = pkt[DNS].id
+                    pkt_dict['dns_transaction_id'] = int(pkt[DNS].id)
 
                 if (dnsqr := pkt.getlayer(DNSQR)) is not None:
                     pkt_dict.update(
@@ -1070,8 +1071,9 @@ class PCAP:
         self.df['time_normed'] = self.df['time'].apply(lambda x: x - self.df.iloc[0]['time'])
 
         # cast all transaction ID's to integers
-        # self.df['dns_transaction_id'] = self.df['dns_transaction_id'].apply(
-        #     lambda x: None if x is None else int(x))
+        # Int64Dtype is pandas optional integer type
+        # https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Int64Dtype.html
+        self.df['dns_transaction_id'] = self.df['dns_transaction_id'].astype(pd.Int64Dtype())
 
         self.df.sort_index(axis=1, inplace=True)
 

--- a/src/netml/pparser/parser.py
+++ b/src/netml/pparser/parser.py
@@ -1242,6 +1242,8 @@ class PCAP:
 
         self.df.sort_index(axis=1, inplace=True)
 
+        self.df.dns_traffic = self.df[self.df['dns_transaction_id'].notnull()]
+
     def pcap2pandas(self):
         """Parse PCAP file into pandas DataFrame.
 

--- a/src/netml/pparser/parser.py
+++ b/src/netml/pparser/parser.py
@@ -1011,6 +1011,7 @@ class PCAP:
                     # the transaction ID is stored in the `.id`
                     # attribute of packet's DNS layer
                     pkt_dict['dns_transaction_id'] = int(pkt[DNS].id)
+                    pkt_dict['dns_record_qtype'] = pkt[DNS].qd.qtype
 
                 if (dnsqr := pkt.getlayer(DNSQR)) is not None:
                     pkt_dict.update(

--- a/src/netml/pparser/parser.py
+++ b/src/netml/pparser/parser.py
@@ -987,6 +987,7 @@ class PCAP:
                     'port_src': None,
                     'is_dns': False,
                     'dns_query': None,
+                    'dns_transaction_id': None,
                     'dns_resp': None,
                 }
 
@@ -1004,6 +1005,11 @@ class PCAP:
                     pkt_dict['protocol'] = 'UDP'
                 elif ICMP in pkt:
                     pkt_dict['protocol'] = 'ICMP'
+
+                if DNS in pkt:
+                    # the transaction ID is stored in the `.id`
+                    # attribute of packet's DNS layer
+                    pkt_dict['dns_transaction_id'] = pkt[DNS].id
 
                 if (dnsqr := pkt.getlayer(DNSQR)) is not None:
                     pkt_dict.update(
@@ -1062,6 +1068,10 @@ class PCAP:
             lambda x: None if x is None else int(netaddr.EUI(x)))
 
         self.df['time_normed'] = self.df['time'].apply(lambda x: x - self.df.iloc[0]['time'])
+
+        # cast all transaction ID's to integers
+        # self.df['dns_transaction_id'] = self.df['dns_transaction_id'].apply(
+        #     lambda x: None if x is None else int(x))
 
         self.df.sort_index(axis=1, inplace=True)
 


### PR DESCRIPTION
Added `pcap.df.dns_traffic` attribute that filters the pcap dataframe for dns traffic only.